### PR TITLE
Use (cider-current-ns) instead of nrepl-buffer-ns

### DIFF
--- a/midje-mode.el
+++ b/midje-mode.el
@@ -201,7 +201,7 @@ Check that fact and also save it for use of
 `midje-recheck-last-fact-checked'."
   (interactive)
   (midje-clear-comments)
-  (setq last-checked-midje-fact-ns nrepl-buffer-ns)
+  (setq last-checked-midje-fact-ns (cider-current-ns))
   (let ((string (save-excursion
                   (mark-defun)
                   (buffer-substring-no-properties (mark) (point)))))
@@ -209,7 +209,7 @@ Check that fact and also save it for use of
     (midje-goto-above-fact)
     (nrepl-send-string string
                        (nrepl-check-fact-handler (current-buffer))
-                       nrepl-buffer-ns)))
+                       (cider-current-ns))))
 
 (defun midje-recheck-last-fact-checked ()
   "Used when `point` is on or just after a def* form.


### PR DESCRIPTION
I got `Symbol's value as variable is void: nrepl-buffer-ns`. I couldn't
find where it used to be and when it disappeared (`git log
-Snrepl-buffer-ns` found nothing), but Cider has switched to using
`(cider-current-ns)` (see clojure-emacs/cider#814), so that seems
appropriate here as well.