### PR TITLE
Fix error about "_" on reward display

### DIFF
--- a/midje-mode.el
+++ b/midje-mode.el
@@ -127,7 +127,7 @@
               (narrow-to-region start (point))
               (goto-char (point-min))
               (fill-paragraph nil)
-              (midje-add-midje-comments (point-min) (point-max))_)))
+              (midje-add-midje-comments (point-min) (point-max)))))
       (progn
         (midje-clear-comments)
         (message "The check(s) for this fact succeeded")))))


### PR DESCRIPTION
It seems that an underscore was inserted at the wrong place in the
code. This triggered this error:

    error in process filter: Symbol's value as variable is void: _

Removing it solves the issue.